### PR TITLE
Removed unexpected bytes_read passed to ctypes.byref

### DIFF
--- a/fdb/fbcore.py
+++ b/fdb/fbcore.py
@@ -2740,7 +2740,8 @@ class PreparedStatement(object):
                                                            min(segment_size,
                                                                blob_length - bytes_read),
                                                            ctypes.byref(
-                                                               blob, bytes_read))
+                                                               blob)
+                                                        )
                             if status != 0:
                                 if ((status == isc_segment)
                                     and allow_incomplete_segment_read):


### PR DESCRIPTION
When reading a blob that is less than __streamed_blob_treshold, existing code attempts to read the blob 'inline' w/o using BlobReader, however the inline read code, which is more than 6 years old, incorrectly passed two arguments to ctypes.byref

I discovered this when back-porting fdb to python 2.3 (don't ask..)