### PR TITLE
Add fb_shutdown_callback and fb_shutdown to internal API

### DIFF
--- a/fdb/ibase.py
+++ b/fdb/ibase.py
@@ -2188,6 +2188,15 @@ class fbclient_API(object):
         #: C_isc_event_block(ISC_LONG, POINTER(POINTER(ISC_UCHAR)), POINTER(POINTER(ISC_UCHAR)), ISC_USHORT)
         self.C_isc_event_block = self.P_isc_event_block(('isc_event_block', fb_library))
         self.P_isc_event_block_args = self.C_isc_event_block.argtypes
+        #: fb_shutdown_callback(POINTER(ISC_STATUS), FB_SHUTDOWN_CALLBACK, c_int, c_void_p)
+        self.fb_shutdown_callback = fb_library.fb_shutdown_callback
+        self.fb_shutdown_callback.restype = ISC_STATUS
+        self.fb_shutdown_callback.argtypes = [POINTER(ISC_STATUS), FB_SHUTDOWN_CALLBACK,
+                                              c_int, c_void_p]
+        #: fb_shutdown(c_int, c_uint, c_int)
+        self.fb_shutdown = fb_library.fb_shutdown
+        self.fb_shutdown.restype = c_int
+        self.fb_shutdown.argtypes = [c_uint, c_int]
 
     def isc_event_block(self, event_buffer, result_buffer, *args):
         "Injects variable number of parameters into C_isc_event_block call"


### PR DESCRIPTION
To allow control shutdown process of driver. For example:

from fdb.ibase import FB_SHUTDOWN_CALLBACK, fb_shut_confirmation,
fb_shutrsn_signal, fb_shutrsn_app_stopped

@FB_SHUTDOWN_CALLBACK
def shutdown_callback(reason, mask, arg):
    if reason == fb_shutrsn_signal:
        return 1
    return 0

status = fdb.ISC_STATUS(0)
fdb.fbcore.api.fb_shutdown_callback(status, shutdown_callback,
fb_shut_confirmation, None)

...

fdb.fbcore.api.fb_shutdown(0, fb_shutrsn_app_stopped)