### PR TITLE
Remove apply() - python3 doesn't have it

### DIFF
--- a/fdb/fbcore.py
+++ b/fdb/fbcore.py
@@ -319,13 +319,13 @@ def Timestamp(year, month, day, hour, minute, second):
     return datetime.datetime(year, month, day, hour, minute, second)
 
 def DateFromTicks(ticks):
-    return apply(Date, time.localtime(ticks)[:3])
+    return Date(*time.localtime(ticks)[:3])
 
 def TimeFromTicks(ticks):
-    return apply(Time, time.localtime(ticks)[3:6])
+    return Time(*time.localtime(ticks)[3:6])
 
 def TimestampFromTicks(ticks):
-    return apply(Timestamp, time.localtime(ticks)[:6])
+    return Timestamp(*time.localtime(ticks)[:6])
 
 def Binary(b):
     return b


### PR DESCRIPTION
Get rid of the obsolete function apply().  Python3 doesn't have it.