### PR TITLE
fixed #117 to be Python 3.13 compatible

### DIFF
--- a/fdb/gstat.py
+++ b/fdb/gstat.py
@@ -25,7 +25,7 @@ from fdb.utils import ObjectList
 import datetime
 import weakref
 from collections import namedtuple
-from locale import LC_ALL, LC_CTYPE, getlocale, setlocale, resetlocale
+from locale import LC_ALL, LC_CTYPE, getlocale, setlocale
 import sys
 
 GSTAT_25 = 2
@@ -658,7 +658,7 @@ def parse(lines):
             if sys.platform == 'win32':
                 setlocale(_LOCALE_, '')
             else:
-                resetlocale(_LOCALE_)
+                setlocale(LC_ALL, '')
         else:
             setlocale(_LOCALE_, locale)
     return db


### PR DESCRIPTION
This pull fixes an incompatibility with Python 3.13 ( Issue #117 ) due to a change in the behaviour of the locale lib, which is deprecated in Python 3.13.
It's quick and dirty, with no version checking, but I've tested it with 3.12.